### PR TITLE
Fixed missing initialization of is_generic and m_valid

### DIFF
--- a/master/include/entry.h
+++ b/master/include/entry.h
@@ -154,12 +154,12 @@ namespace kaco {
 		/// This is set to true, if the entry has been created through a default CiA EDS file.
 		/// This means that it's not guaranteed that the entry actually exists in the current device.
 		/// For manually added entries and entries from manufacturer-specific EDS files, this is set to false.
-		bool is_generic;
+		bool is_generic = false;
 
 	private:
 
 		Value m_value;
-		bool m_valid;
+		bool m_valid = false;
 		Value m_dummy_value;
 
 		std::vector<ValueChangedCallback> m_value_changed_callbacks;


### PR DESCRIPTION
The default constructor of kaco::Entry does not initialize all members. This causes kacanopen_example_eds_reader to fail. Initializers common to all constructors can now placed in the declaration, so I fixed it there.