### PR TITLE
Return flag to users for TPDO send errors

### DIFF
--- a/core/include/core.h
+++ b/core/include/core.h
@@ -99,7 +99,8 @@ namespace kaco {
 
 		/// Sends a message
 		/// \remark thread-safe if m_lock_send==true or driver is thread-safe.
-		void send(const Message& message);
+		/// \returns true if successful
+		bool send(const Message& message);
 
 		/// Registers a callback function which is called when a message has been received.
 		/// \remark thread-safe

--- a/core/include/pdo.h
+++ b/core/include/pdo.h
@@ -86,7 +86,8 @@ namespace kaco {
 		/// \param cob_id COB-ID of the message to send
 		/// \param data A vector containing the data bytes to send. PDOs can have most 8 bytes!
 		/// \remark thread-safe
-		void send(uint16_t cob_id, const std::vector<uint8_t>& data);
+		/// \returns true if successful
+		bool send(uint16_t cob_id, const std::vector<uint8_t>& data);
 
 		/// Adds a callback which will be called when a PDO has been received with the given COB-ID.
 		/// \param cob_id COB-ID to listen for

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -240,7 +240,7 @@ void Core::received_message(const Message& message) {
 
 }
 
-void Core::send(const Message& message) {
+bool Core::send(const Message& message) {
 	
 	if (m_lock_send) {
 		m_send_mutex.lock();
@@ -248,12 +248,16 @@ void Core::send(const Message& message) {
 	
 	DEBUG_LOG_EXHAUSTIVE("Sending message:");
 	DEBUG_EXHAUSTIVE(message.print();)
-	canSend_driver(m_handle, &message);
+	uint8_t retval = canSend_driver(m_handle, &message);
 	
 	if (m_lock_send) {
 		m_send_mutex.unlock();
 	}
-
+	
+	if (retval != 0) {
+		return false;
+	}
+	return true;
 }
 
 } // namespace co

--- a/core/src/pdo.cpp
+++ b/core/src/pdo.cpp
@@ -80,7 +80,7 @@ void PDO::process_incoming_message(const Message& message) const {
 
 }
 
-void PDO::send(uint16_t cob_id, const std::vector<uint8_t>& data) {
+bool PDO::send(uint16_t cob_id, const std::vector<uint8_t>& data) {
 	
 	assert(data.size()<=8 && "[PDO::send] A PDO message can have at most 8 data bytes.");
 
@@ -95,7 +95,7 @@ void PDO::send(uint16_t cob_id, const std::vector<uint8_t>& data) {
 	DEBUG_LOG_EXHAUSTIVE("Sending the following PDO:");
 	DEBUG_EXHAUSTIVE(message.print();)
 
-	m_core.send(message);
+	return m_core.send(message);
 
 }
 

--- a/drivers_lgpl/socket/can_socket.c
+++ b/drivers_lgpl/socket/can_socket.c
@@ -119,7 +119,9 @@ canSend_driver (CAN_HANDLE fd0, Message const * m)
   res = CAN_SEND (*(int *) fd0, &frame, sizeof (frame), 0);
   if (res < 0)
     {
+#if defined DEBUG_MSG_CONSOLE_ON
       fprintf (stderr, "Send failed: %s\n", strerror (CAN_ERRNO (res)));
+#endif
       return 1;
     }
 


### PR DESCRIPTION
Before this change, the caller of `Core::send()` `PDO::send()` had no way to know when the send failed (the return value was void). The underlying driver send functions do return values though. This PR just passes those up through Core and PDO classes. This changes the return type of the functions, but shouldn't require anyone ussing these functions to change code. If they were expecting void return type before, now they'll just not do anything with the returned bool.

It will, however, require people to recompile, since the ABI will change.
