### PR TITLE
Add support for velocity/effort mode via ROS bridge

### DIFF
--- a/examples/ros/motor_and_io_bridge.cpp
+++ b/examples/ros/motor_and_io_bridge.cpp
@@ -117,6 +117,7 @@ int main(int argc, char* argv[]) {
 
 			found = true;
 
+			// Choose between "profile_position_mode", "profile_velocity_mode", or "torque_mode"
 			PRINT("Set position mode");
 			device.set_entry("modes_of_operation", device.get_constant("profile_position_mode"));
 

--- a/examples/ros/motor_and_io_bridge.cpp
+++ b/examples/ros/motor_and_io_bridge.cpp
@@ -35,7 +35,7 @@
 #include "joint_state_subscriber.h"
 #include "entry_publisher.h"
 #include "entry_subscriber.h"
- 
+
 #include <thread>
 #include <chrono>
 #include <memory>
@@ -125,10 +125,10 @@ int main(int argc, char* argv[]) {
 
 			// TODO: target_position should be mapped to a PDO
 
-			auto jspub = std::make_shared<kaco::JointStatePublisher>(device, 0, 350000);
+			auto jspub = std::make_shared<kaco::JointStatePublisher>(device, 0, 350000, 1, 60);
 			bridge.add_publisher(jspub, loop_rate);
-			
-			auto jssub = std::make_shared<kaco::JointStateSubscriber>(device, 0, 350000);
+
+			auto jssub = std::make_shared<kaco::JointStateSubscriber>(device, 0, 350000, 1, 60);
 			bridge.add_subscriber(jssub);
 
 		}

--- a/master/src/master.cpp
+++ b/master/src/master.cpp
@@ -28,7 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #include "master.h"
 #include "core.h"
 #include "logger.h"
@@ -93,7 +93,7 @@ void Master::device_alive_callback(const uint8_t node_id) {
 	} else {
 		WARN("Device with node ID "<<node_id<<" already exists. Ignoring...");
 	}
-	
+
 }
 
 

--- a/master/src/profiles.cpp
+++ b/master/src/profiles.cpp
@@ -76,6 +76,22 @@ namespace kaco {
 						device.execute("unset_controlword_flag","controlword_pp_new_set_point");
 						return Value();
 					}
+				},
+				{
+					"set_target_velocity",
+					[](Device& device,const Value& target_velocity) -> Value {
+						DEBUG_LOG("Set target vel to "<<target_velocity);
+						device.set_entry("Target velocity", target_velocity);
+						return Value();
+					}
+				},
+				{
+					"set_target_torque",
+					[](Device& device,const Value& target_torque) -> Value {
+						DEBUG_LOG("Set target tor to "<<target_torque);
+						device.set_entry("Target torque", target_torque);
+						return Value();
+					}
 				}
 			}
 		}
@@ -112,15 +128,15 @@ namespace kaco {
 				{ "controlword_vl_rfg_enable",	static_cast<uint16_t>(1<<4) },
 				{ "controlword_vl_rfg_unlock",	static_cast<uint16_t>(1<<5) },
 				{ "controlword_vl_use_ref",		static_cast<uint16_t>(1<<6) },
-				
+
 				// control word flags profile position mode specific
 				{ "controlword_pp_new_set_point",				static_cast<uint16_t>(1<<4) },
 				{ "controlword_pp_change_set_immediately",		static_cast<uint16_t>(1<<5) },
 				{ "controlword_pp_abs_rel",						static_cast<uint16_t>(1<<6) },
-				
+
 				// control word flags homing mode specific
 				{ "controlword_hm_operation_start",	static_cast<uint16_t>(1<<4) },
-				
+
 				// control word flags interpolated position mode specific
 				{ "controlword_ip_enable_ip_mode",	static_cast<uint16_t>(1<<4) },
 
@@ -145,15 +161,15 @@ namespace kaco {
 				// status word flags profile position mode specific
 				{ "statusword_pp_set_point_acknowledge",	static_cast<uint16_t>(1<<12) },
 				{ "statusword_pp_following_error",			static_cast<uint16_t>(1<<13) },
-				
+
 				// status word flags profile velocity mode specific
 				{ "statusword_pv_speed",				static_cast<uint16_t>(1<<12) },
 				{ "statusword_pv_max_slippage_error",	static_cast<uint16_t>(1<<13) },
-				
+
 				// status word flags homing mode specific
 				{ "statusword_hm_homing_attained",	static_cast<uint16_t>(1<<12) },
 				{ "statusword_hm_homing_error",		static_cast<uint16_t>(1<<13) },
-				
+
 				// status word flags interpolated position mode specific
 				{ "statusword_ip_ip_mode_active",	static_cast<uint16_t>(1<<12) }
 			}

--- a/ros_bridge/include/bridge.h
+++ b/ros_bridge/include/bridge.h
@@ -28,7 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #pragma once
 
 #include "master.h"

--- a/ros_bridge/include/entry_publisher.h
+++ b/ros_bridge/include/entry_publisher.h
@@ -28,7 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #pragma once
 
 #include "device.h"
@@ -37,20 +37,21 @@
 
 #include <string>
 
-namespace kaco {
+namespace kaco
+{
 
 	/// This class provides a Publisher implementation for
 	/// use with kaco::Bridge. It publishes a value from
 	/// a device's dictionary.
-	class EntryPublisher : public Publisher {
+	class EntryPublisher : public Publisher
+	{
 
 	public:
-
 		/// Constructor
 		/// \param device The CanOpen device
 		/// \param entry_name The name of the entry. See device profile.
 		/// \param access_method You can choose default/sdo/pdo method. See kaco::Device docs.
-		EntryPublisher(Device& device, const std::string& entry_name, const ReadAccessMethod access_method = ReadAccessMethod::use_default);
+		EntryPublisher(Device &device, const std::string &entry_name, const ReadAccessMethod access_method = ReadAccessMethod::use_default);
 
 		/// \see interface Publisher
 		void advertise() override;
@@ -59,7 +60,6 @@ namespace kaco {
 		void publish() override;
 
 	private:
-
 		static const bool debug = false;
 
 		// TODO: let the user change this?
@@ -69,11 +69,10 @@ namespace kaco {
 		std::string m_device_prefix;
 		std::string m_name;
 
-		Device& m_device;
+		Device &m_device;
 		std::string m_entry_name;
 		ReadAccessMethod m_access_method;
 		Type m_type;
-
 	};
 
 } // end namespace kaco

--- a/ros_bridge/include/entry_subscriber.h
+++ b/ros_bridge/include/entry_subscriber.h
@@ -28,7 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #pragma once
 
 #include "device.h"
@@ -43,38 +43,38 @@
 #include "std_msgs/Int32.h"
 #include "std_msgs/Bool.h"
 #include "std_msgs/String.h"
- 
+
 #include <string>
 #include <thread>
 
-namespace kaco {
+namespace kaco
+{
 
 	/// This class provides a Publisher implementation for
 	/// use with kaco::Bridge. It publishes a value from
 	/// a device's dictionary.
-	class EntrySubscriber : public Subscriber {
+	class EntrySubscriber : public Subscriber
+	{
 
 	public:
-
 		/// Constructor
 		/// \param device The CanOpen device
 		/// \param entry_name The name of the entry. See device profile.
 		/// \param access_method You can choose default/sdo/pdo method. See kaco::Device docs.
-		EntrySubscriber(Device& device, const std::string& entry_name, const WriteAccessMethod access_method = WriteAccessMethod::use_default);
+		EntrySubscriber(Device &device, const std::string &entry_name, const WriteAccessMethod access_method = WriteAccessMethod::use_default);
 
 		/// \see interface Subscriber
 		void advertise() override;
 
 	private:
-
-		void receive_uint8(const std_msgs::UInt8& msg);
-		void receive_uint16(const std_msgs::UInt16& msg);
-		void receive_uint32(const std_msgs::UInt32& msg);
-		void receive_int8(const std_msgs::Int8& msg);
-		void receive_int16(const std_msgs::Int16& msg);
-		void receive_int32(const std_msgs::Int32& msg);
-		void receive_boolean(const std_msgs::Bool& msg);
-		void receive_string(const std_msgs::String& msg);
+		void receive_uint8(const std_msgs::UInt8 &msg);
+		void receive_uint16(const std_msgs::UInt16 &msg);
+		void receive_uint32(const std_msgs::UInt32 &msg);
+		void receive_int8(const std_msgs::Int8 &msg);
+		void receive_int16(const std_msgs::Int16 &msg);
+		void receive_int32(const std_msgs::Int32 &msg);
+		void receive_boolean(const std_msgs::Bool &msg);
+		void receive_string(const std_msgs::String &msg);
 
 		static const bool debug = false;
 
@@ -85,11 +85,10 @@ namespace kaco {
 		std::string m_device_prefix;
 		std::string m_name;
 
-		Device& m_device;
+		Device &m_device;
 		std::string m_entry_name;
 		WriteAccessMethod m_access_method;
 		Type m_type;
-
 	};
 
 } // end namespace kaco

--- a/ros_bridge/include/joint_state_publisher.h
+++ b/ros_bridge/include/joint_state_publisher.h
@@ -28,17 +28,18 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #pragma once
 
 #include "device.h"
 #include "publisher.h"
 #include "ros/ros.h"
- 
+
 #include <string>
 #include <cmath>
 
-namespace kaco {
+namespace kaco
+{
 
 	/// This class provides a Publisher implementation for
 	/// use with kaco::Bridge and a CiA 402 motor device.
@@ -48,10 +49,10 @@ namespace kaco {
 	/// Currenty, only the motor angle is published.
 	/// You have to initialize the motor on your own.
 	/// The motor is expected to be in position mode.
-	class JointStatePublisher : public Publisher {
+	class JointStatePublisher : public Publisher
+	{
 
 	public:
-
 		/// Constructor
 		/// \param device a CiA 402 compliant motor device object
 		/// \param position_0_degree The motor position (dictionary
@@ -62,8 +63,15 @@ namespace kaco {
 		/// \param position_actual_field Name of the dictionary entry to use.
 		/// \param topic_name Custom topic name. Leave out for default.
 		/// \throws std::runtime_error if device is not CiA 402 compliant and in position_mode.
-		JointStatePublisher(Device& device, int32_t position_0_degree,
-			int32_t position_360_degree, const std::string& position_actual_field = "Position actual value", const std::string& topic_name = "");
+		JointStatePublisher(Device &device,
+							int32_t position_0_degree,
+							int32_t position_360_degree,
+							int32_t velocity_nominator,
+							int32_t velocity_denominator,
+							const std::string &position_actual_field = "Position actual value",
+							const std::string &velocity_actual_field = "Velocity actual value",
+							const std::string& torque_actual_field = "Torque actual value",
+							const std::string &topic_name = "");
 
 		/// \see interface Publisher
 		void advertise() override;
@@ -72,27 +80,36 @@ namespace kaco {
 		void publish() override;
 
 	private:
-
 		static const bool debug = false;
 
 		// TODO: let the user change this?
 		static const unsigned queue_size = 100;
 
-		/// converts "position actiual value" from CanOpen to radiant using m_position_0_degree and m_position_360_degree
-		double pos_to_rad(int32_t pos) const;
+		/// converts "position actual value" from CanOpen to revolutions using m_position_0_degree and m_position_360_degree
+		double pos_to_rev(int32_t pos) const;
+
+		/// converts "velocity actual value" from CanOpen to revolutions per second using m_velocity_nominator and m_velocity_denominator
+		double vel_to_rev_p_s(int32_t vel) const;
+
+		/// converts "torque actual value" from CanOpen to effort
+		double tor_to_eff(int32_t tor) const;
+
 
 		/// constant PI
 		static constexpr double pi() { return std::acos(-1); }
 
-		Device& m_device;
+		Device &m_device;
 		int32_t m_position_0_degree;
 		int32_t m_position_360_degree;
+		int32_t m_velocity_nominator;
+		int32_t m_velocity_denominator;
 		std::string m_position_actual_field;
+		std::string m_velocity_actual_field;
+		std::string m_torque_actual_field;
 		std::string m_topic_name;
 		bool m_initialized;
 
 		ros::Publisher m_publisher;
-
 	};
 
 } // end namespace kaco

--- a/ros_bridge/include/joint_state_subscriber.h
+++ b/ros_bridge/include/joint_state_subscriber.h
@@ -28,18 +28,19 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #pragma once
 
 #include "device.h"
 #include "subscriber.h"
 #include "ros/ros.h"
 #include "sensor_msgs/JointState.h"
- 
+
 #include <string>
 #include <cmath>
 
-namespace kaco {
+namespace kaco
+{
 
 	/// This class provides a Subscriber implementation for
 	/// use with kaco::Bridge and a CiA 402 motor device.
@@ -51,10 +52,10 @@ namespace kaco {
 	/// You have to initialize the motor on your own.
 	/// The motor is expected to be in position mode and
 	/// operational state.
-	class JointStateSubscriber : public Subscriber {
+	class JointStateSubscriber : public Subscriber
+	{
 
 	public:
-
 		/// Constructor
 		/// \param device a CiA 402 compliant motor device object
 		/// \param position_0_degree The motor position (dictionary
@@ -64,36 +65,46 @@ namespace kaco {
 		/// 360 degree state.
 		/// \param topic_name Custom topic name. Leave out for default.
 		/// \throws std::runtime_error if device is not CiA 402 compliant and in position_mode.
-		JointStateSubscriber(Device& device, int32_t position_0_degree,
-			int32_t position_360_degree, std::string topic_name = "");
+		JointStateSubscriber(Device &device,
+							 int32_t position_0_degree,
+							 int32_t position_360_degree,
+							 int32_t velocity_nominator,
+							 int32_t velocity_denominator,
+							 std::string topic_name = "");
 
 		/// \see interface Subscriber
 		void advertise() override;
 
 	private:
-
 		static const bool debug = false;
 
 		// TODO: let the user change this?
-		static const unsigned queue_size = 100;
+		static const unsigned queue_size = 1;
 
 		/// Callback "received ROS JointState message"
-		void receive(const sensor_msgs::JointState& msg);
+		void receive(const sensor_msgs::JointState &msg);
 
-		/// converts radiant to "Target position" value from CanOpen using m_position_0_degree and m_position_360_degree
-		int32_t rad_to_pos(double pos) const;
+		/// converts revolutions to "Target position" value from CanOpen using m_position_0_degree and m_position_360_degree
+		int32_t rev_to_pos(double pos) const;
+
+		/// converts revolutions per second to "velocity actual value" from CanOpen using m_velocity_nominator and m_velocity_denominator
+		int32_t rev_p_s_to_vel(double rad) const;
+
+		/// converts effort to "torque actual value" from CanOpen
+		int32_t eff_to_tor(double eff) const;
 
 		/// constant PI
 		static constexpr double pi() { return std::acos(-1); }
 
-		Device& m_device;
+		Device &m_device;
 		int32_t m_position_0_degree;
 		int32_t m_position_360_degree;
+		int32_t m_velocity_nominator;
+		int32_t m_velocity_denominator;
 		std::string m_topic_name;
 		bool m_initialized;
 
 		ros::Subscriber m_subscriber;
-
 	};
 
 } // end namespace kaco

--- a/ros_bridge/include/publisher.h
+++ b/ros_bridge/include/publisher.h
@@ -28,16 +28,17 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #pragma once
 
-namespace kaco {
+namespace kaco
+{
 
 	/// Interface, which provides methods for publishing topics.
-	class Publisher {
+	class Publisher
+	{
 
 	public:
-
 		/// Advertise the publisher to the network. This is called by
 		/// Bridge _after_ ros::init(). You should not call this
 		/// method by yourself.
@@ -47,8 +48,7 @@ namespace kaco {
 		virtual void publish() = 0;
 
 		// Virtual destructor must be defined!
-		virtual ~Publisher() { }
-
+		virtual ~Publisher() {}
 	};
 
 } // end namespace kaco

--- a/ros_bridge/include/subscriber.h
+++ b/ros_bridge/include/subscriber.h
@@ -28,24 +28,24 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #pragma once
 
-namespace kaco {
+namespace kaco
+{
 
 	/// Interface, which provides methods for subscribing topics.
-	class Subscriber {
+	class Subscriber
+	{
 
 	public:
-
 		/// Advertise the subscriber to the network. This is called by
 		/// Bridge _after_ ros::init(). You should not call this
 		/// method by yourself.
 		virtual void advertise() = 0;
 
 		// Virtual destructor must be defined!
-		virtual ~Subscriber() { }
-
+		virtual ~Subscriber() {}
 	};
 
 } // end namespace kaco

--- a/ros_bridge/src/bridge.cpp
+++ b/ros_bridge/src/bridge.cpp
@@ -28,7 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #include "bridge.h"
 #include "logger.h"
 #include "sdo_error.h"
@@ -36,31 +36,35 @@
 
 #include <future>
 
-namespace kaco {
+namespace kaco
+{
 
-void Bridge::add_publisher(std::shared_ptr<Publisher> publisher, double loop_rate) {
-	m_publishers.push_back(publisher);
-	publisher->advertise();
-	m_futures.push_front(
-		std::async(std::launch::async, [publisher,loop_rate,this](){
-			ros::Rate rate(loop_rate);
-			while(ros::ok()) {
-				publisher->publish();
-				rate.sleep();
-			}
-		})
-	);
-}
+	void Bridge::add_publisher(std::shared_ptr<Publisher> publisher, double loop_rate)
+	{
+		m_publishers.push_back(publisher);
+		publisher->advertise();
+		m_futures.push_front(
+			std::async(std::launch::async, [publisher, loop_rate, this]() {
+				ros::Rate rate(loop_rate);
+				while (ros::ok())
+				{
+					publisher->publish();
+					rate.sleep();
+				}
+			}));
+	}
 
-void Bridge::add_subscriber(std::shared_ptr<Subscriber> subscriber) {
-	m_subscribers.push_back(subscriber);
-	subscriber->advertise();
-}
+	void Bridge::add_subscriber(std::shared_ptr<Subscriber> subscriber)
+	{
+		m_subscribers.push_back(subscriber);
+		subscriber->advertise();
+	}
 
-void Bridge::run() {
-	ros::AsyncSpinner spinner(0);
-	spinner.start();
-	ros::waitForShutdown();
-}
+	void Bridge::run()
+	{
+		ros::AsyncSpinner spinner(0);
+		spinner.start();
+		ros::waitForShutdown();
+	}
 
 } // end namespace kaco

--- a/ros_bridge/src/entry_publisher.cpp
+++ b/ros_bridge/src/entry_publisher.cpp
@@ -28,7 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #include "entry_publisher.h"
 #include "utils.h"
 #include "logger.h"
@@ -46,27 +46,29 @@
 
 #include <string>
 
-namespace kaco {
-
-EntryPublisher::EntryPublisher(Device& device, const std::string& entry_name, const ReadAccessMethod access_method)
-	: m_device(device), m_entry_name(entry_name), m_access_method(access_method)
+namespace kaco
 {
 
-	uint8_t node_id = device.get_node_id();
-	m_device_prefix = "device" + std::to_string(node_id) + "/";
-	// no spaces and '-' allowed in ros names
-	m_name = Utils::escape(entry_name);
-	m_type = device.get_entry_type(entry_name);
+	EntryPublisher::EntryPublisher(Device &device, const std::string &entry_name, const ReadAccessMethod access_method)
+		: m_device(device), m_entry_name(entry_name), m_access_method(access_method)
+	{
 
-}
+		uint8_t node_id = device.get_node_id();
+		m_device_prefix = "device" + std::to_string(node_id) + "/";
+		// no spaces and '-' allowed in ros names
+		m_name = Utils::escape(entry_name);
+		m_type = device.get_entry_type(entry_name);
+	}
 
-void EntryPublisher::advertise() {
+	void EntryPublisher::advertise()
+	{
 
-	std::string topic = m_device_prefix+"get_"+m_name;
-	DEBUG_LOG("Advertising "<<topic);
-	ros::NodeHandle nh;
+		std::string topic = m_device_prefix + "get_" + m_name;
+		DEBUG_LOG("Advertising " << topic);
+		ros::NodeHandle nh;
 
-	switch(m_type) {
+		switch (m_type)
+		{
 		case Type::uint8:
 			m_publisher = nh.advertise<std_msgs::UInt8>(topic, queue_size);
 			break;
@@ -93,75 +95,86 @@ void EntryPublisher::advertise() {
 			break;
 		default:
 			ERROR("[EntryPublisher::advertise] Invalid entry type.")
+		}
 	}
 
-}
+	void EntryPublisher::publish()
+	{
 
-void EntryPublisher::publish() {
+		try
+		{
 
-	try {
+			Value value = m_device.get_entry(m_entry_name, m_access_method);
 
-		Value value = m_device.get_entry(m_entry_name, m_access_method);
-
-		switch(m_type) {
-			case Type::uint8: {
+			switch (m_type)
+			{
+			case Type::uint8:
+			{
 				std_msgs::UInt8 msg;
 				msg.data = value; // auto cast!
 				m_publisher.publish(msg);
 				break;
 			}
-			case Type::uint16: {
+			case Type::uint16:
+			{
 				std_msgs::UInt16 msg;
 				msg.data = value; // auto cast!
 				m_publisher.publish(msg);
 				break;
 			}
-			case Type::uint32: {
+			case Type::uint32:
+			{
 				std_msgs::UInt32 msg;
 				msg.data = value; // auto cast!
 				m_publisher.publish(msg);
 				break;
 			}
-			case Type::int8: {
+			case Type::int8:
+			{
 				std_msgs::Int8 msg;
 				msg.data = value; // auto cast!
 				m_publisher.publish(msg);
 				break;
 			}
-			case Type::int16: {
+			case Type::int16:
+			{
 				std_msgs::Int16 msg;
 				msg.data = value; // auto cast!
 				m_publisher.publish(msg);
 				break;
 			}
-			case Type::int32: {
+			case Type::int32:
+			{
 				std_msgs::Int32 msg;
 				msg.data = value; // auto cast!
 				m_publisher.publish(msg);
 				break;
 			}
-			case Type::boolean: {
+			case Type::boolean:
+			{
 				std_msgs::Bool msg;
 				msg.data = value; // auto cast!
 				m_publisher.publish(msg);
 				break;
 			}
-			case Type::string: {
+			case Type::string:
+			{
 				std_msgs::String msg;
-				msg.data = (std::string) value;
+				msg.data = (std::string)value;
 				m_publisher.publish(msg);
 				break;
 			}
-			default: {
+			default:
+			{
 				ERROR("[EntryPublisher::advertise] Invalid entry type.")
 			}
+			}
 		}
-		
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in EntryPublisher::publish(): "<<error.what());
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in EntryPublisher::publish(): " << error.what());
+		}
 	}
-
-}
 
 } // end namespace kaco

--- a/ros_bridge/src/entry_subscriber.cpp
+++ b/ros_bridge/src/entry_subscriber.cpp
@@ -28,7 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #include "entry_subscriber.h"
 #include "utils.h"
 #include "logger.h"
@@ -37,135 +37,176 @@
 
 #include <string>
 
-namespace kaco {
-
-EntrySubscriber::EntrySubscriber(Device& device, const std::string& entry_name, const WriteAccessMethod access_method)
-	: m_device(device), m_entry_name(entry_name), m_access_method(access_method)
+namespace kaco
 {
 
-	uint8_t node_id = device.get_node_id();
-	m_device_prefix = "device" + std::to_string(node_id) + "/";
-	// no spaces and '-' allowed in ros names
-	m_name = Utils::escape(entry_name);
-	m_type = device.get_entry_type(entry_name);
+	EntrySubscriber::EntrySubscriber(Device &device, const std::string &entry_name, const WriteAccessMethod access_method)
+		: m_device(device), m_entry_name(entry_name), m_access_method(access_method)
+	{
 
-}
+		uint8_t node_id = device.get_node_id();
+		m_device_prefix = "device" + std::to_string(node_id) + "/";
+		// no spaces and '-' allowed in ros names
+		m_name = Utils::escape(entry_name);
+		m_type = device.get_entry_type(entry_name);
+	}
 
-void EntrySubscriber::advertise() {
-	
-	std::string topic = m_device_prefix+"set_"+m_name;
-	DEBUG_LOG("Advertising "<<topic);
-	ros::NodeHandle nh;
+	void EntrySubscriber::advertise()
+	{
 
-	switch(m_type) {
+		std::string topic = m_device_prefix + "set_" + m_name;
+		DEBUG_LOG("Advertising " << topic);
+		ros::NodeHandle nh;
+
+		switch (m_type)
+		{
 		case Type::uint8:
 			m_subscriber = nh.subscribe(topic, queue_size, &EntrySubscriber::receive_uint8, this);
+			PRINT("Type is uint8");
 			break;
 		case Type::uint16:
 			m_subscriber = nh.subscribe(topic, queue_size, &EntrySubscriber::receive_uint16, this);
+			PRINT("Type is unit16");
 			break;
 		case Type::uint32:
 			m_subscriber = nh.subscribe(topic, queue_size, &EntrySubscriber::receive_uint32, this);
+			PRINT("Type is uint32");
 			break;
 		case Type::int8:
 			m_subscriber = nh.subscribe(topic, queue_size, &EntrySubscriber::receive_int8, this);
+			PRINT("Type is int8");
 			break;
 		case Type::int16:
+			PRINT("Type is int16");
 			m_subscriber = nh.subscribe(topic, queue_size, &EntrySubscriber::receive_int16, this);
 			break;
 		case Type::int32:
 			m_subscriber = nh.subscribe(topic, queue_size, &EntrySubscriber::receive_int32, this);
+			PRINT("Type is int32");
 			break;
 		case Type::boolean:
 			m_subscriber = nh.subscribe(topic, queue_size, &EntrySubscriber::receive_boolean, this);
+			PRINT("Type is bool");
 			break;
 		case Type::string:
 			m_subscriber = nh.subscribe(topic, queue_size, &EntrySubscriber::receive_string, this);
+			PRINT("Type is string");
 			break;
 		default:
 			ERROR("[EntryPublisher::advertise] Invalid entry type.")
+		}
 	}
 
-}
-
-void EntrySubscriber::receive_uint8(const std_msgs::UInt8& msg) {
-	try {
-		DEBUG_LOG("Recieved msg: "<<msg.data);
-		m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in EntrySubscriber::receive_uint8(): "<<error.what());
+	void EntrySubscriber::receive_uint8(const std_msgs::UInt8 &msg)
+	{
+		try
+		{
+			DEBUG_LOG("Recieved msg: " << msg.data);
+			m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
+		}
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in EntrySubscriber::receive_uint8(): " << error.what());
+		}
 	}
-}
 
-void EntrySubscriber::receive_uint16(const std_msgs::UInt16& msg) {
-	try {
-		DEBUG_LOG("Recieved msg: "<<msg.data);
-		m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in EntrySubscriber::receive_uint16(): "<<error.what());
+	void EntrySubscriber::receive_uint16(const std_msgs::UInt16 &msg)
+	{
+		try
+		{
+			DEBUG_LOG("Recieved msg: " << msg.data);
+			m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
+		}
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in EntrySubscriber::receive_uint16(): " << error.what());
+		}
 	}
-}
 
-void EntrySubscriber::receive_uint32(const std_msgs::UInt32& msg) {
-	try {
-		DEBUG_LOG("Recieved msg: "<<msg.data);
-		m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in EntrySubscriber::receive_uint32(): "<<error.what());
+	void EntrySubscriber::receive_uint32(const std_msgs::UInt32 &msg)
+	{
+		try
+		{
+			DEBUG_LOG("Recieved msg: " << msg.data);
+			m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
+		}
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in EntrySubscriber::receive_uint32(): " << error.what());
+		}
 	}
-}
 
-void EntrySubscriber::receive_int8(const std_msgs::Int8& msg) {
-	try {
-		DEBUG_LOG("Recieved msg: "<<msg.data);
-		m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in EntrySubscriber::receive_int8(): "<<error.what());
+	void EntrySubscriber::receive_int8(const std_msgs::Int8 &msg)
+	{
+		try
+		{
+			DEBUG_LOG("Recieved msg: " << msg.data);
+			m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
+		}
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in EntrySubscriber::receive_int8(): " << error.what());
+		}
 	}
-}
 
-void EntrySubscriber::receive_int16(const std_msgs::Int16& msg) {
-	try {
-		DEBUG_LOG("Recieved msg: "<<msg.data);
-		m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in EntrySubscriber::receive_int16(): "<<error.what());
+	void EntrySubscriber::receive_int16(const std_msgs::Int16 &msg)
+	{
+		try
+		{
+			DEBUG_LOG("Recieved msg: " << msg.data);
+			m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
+		}
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in EntrySubscriber::receive_int16(): " << error.what());
+		}
 	}
-}
 
-void EntrySubscriber::receive_int32(const std_msgs::Int32& msg) {
-	try {
-		DEBUG_LOG("Recieved msg: "<<msg.data);
-		m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in EntrySubscriber::receive_int32(): "<<error.what());
+	void EntrySubscriber::receive_int32(const std_msgs::Int32 &msg)
+	{
+		try
+		{
+			DEBUG_LOG("Recieved msg: " << msg.data);
+			m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
+		}
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in EntrySubscriber::receive_int32(): " << error.what());
+		}
 	}
-}
 
-void EntrySubscriber::receive_boolean(const std_msgs::Bool& msg) {
-	try {
-		DEBUG_LOG("Recieved msg: "<<msg.data);
-		m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in EntrySubscriber::receive_boolean(): "<<error.what());
+	void EntrySubscriber::receive_boolean(const std_msgs::Bool &msg)
+	{
+		try
+		{
+			DEBUG_LOG("Recieved msg: " << msg.data);
+			m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
+		}
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in EntrySubscriber::receive_boolean(): " << error.what());
+		}
 	}
-}
 
-void EntrySubscriber::receive_string(const std_msgs::String& msg) {
-	try {
-		DEBUG_LOG("Recieved msg: "<<msg.data);
-		m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in EntrySubscriber::receive_string(): "<<error.what());
+	void EntrySubscriber::receive_string(const std_msgs::String &msg)
+	{
+		try
+		{
+			DEBUG_LOG("Recieved msg: " << msg.data);
+			m_device.set_entry(m_entry_name, msg.data, m_access_method); // auto cast to Value!
+		}
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in EntrySubscriber::receive_string(): " << error.what());
+		}
 	}
-}
 
 } // end namespace kaco

--- a/ros_bridge/src/joint_state_publisher.cpp
+++ b/ros_bridge/src/joint_state_publisher.cpp
@@ -28,7 +28,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #include "joint_state_publisher.h"
 #include "utils.h"
 #include "logger.h"
@@ -41,91 +41,129 @@
 #include <string>
 #include <stdexcept>
 
-namespace kaco {
-
-JointStatePublisher::JointStatePublisher(Device& device, int32_t position_0_degree,
-	int32_t position_360_degree, const std::string& position_actual_field, const std::string& topic_name)
-	: m_device(device), m_position_0_degree(position_0_degree),
-		m_position_360_degree(position_360_degree), m_position_actual_field(position_actual_field), m_topic_name(topic_name), m_initialized(false)
+namespace kaco
 {
 
-	const uint16_t profile = device.get_device_profile_number();
+	JointStatePublisher::JointStatePublisher(Device &device,
+											 int32_t position_0_degree,
+											 int32_t position_360_degree,
+											 int32_t velocity_nominator,
+											 int32_t velocity_denominator,
+											 const std::string &position_actual_field,
+											 const std::string &velocity_actual_field,
+											 const std::string &torque_actual_field,
+											 const std::string &topic_name)
+		: m_device(device),
+		  m_position_0_degree(position_0_degree),
+		  m_position_360_degree(position_360_degree),
+		  m_velocity_nominator(velocity_nominator),
+		  m_velocity_denominator(velocity_denominator),
+		  m_position_actual_field(position_actual_field),
+		  m_velocity_actual_field(velocity_actual_field),
+		  m_torque_actual_field(torque_actual_field),
+		  m_topic_name(topic_name),
+		  m_initialized(false)
+	{
 
-	if (profile != 402) {
-		throw std::runtime_error("JointStatePublisher can only be used with a CiA 402 device."
-			" You passed a device with profile number "+std::to_string(profile));
-	}
+		const uint16_t profile = device.get_device_profile_number();
 
-	const Value operation_mode = device.get_entry("Modes of operation display");
-
-	// TODO: look into INTERPOLATED_POSITION_MODE
-	if (operation_mode != Profiles::constants.at(402).at("profile_position_mode")
-		&& operation_mode != Profiles::constants.at(402).at("interpolated_position_mode")) {
-		throw std::runtime_error("[JointStatePublisher] Only position mode supported yet."
-			" Try device.set_entry(\"modes_of_operation\", device.get_constant(\"profile_position_mode\"));");
-		return;
-	}
-
-	if (m_topic_name.empty()) {
-		uint8_t node_id = device.get_node_id();
-		m_topic_name = "device" + std::to_string(node_id) + "/get_joint_state";
-	}
-
-}
-
-void JointStatePublisher::advertise() {
-
-	assert(!m_topic_name.empty());
-	DEBUG_LOG("Advertising "<<m_topic_name);
-	ros::NodeHandle nh;
-	m_publisher = nh.advertise<sensor_msgs::JointState>(m_topic_name, queue_size);
-	m_initialized = true;
-
-}
-
-void JointStatePublisher::publish() {
-
-	try {
-
-		if (!m_initialized) {
-			throw std::runtime_error("[JointStatePublisher] publish() called before advertise().");
+		if (profile != 402)
+		{
+			throw std::runtime_error("JointStatePublisher can only be used with a CiA 402 device."
+									 " You passed a device with profile number " +
+									 std::to_string(profile));
 		}
 
-		sensor_msgs::JointState js;
-
-		js.name.resize(1);
-		js.position.resize(1);
-
-		// only position supported yet.
-		js.velocity.resize(0);
-		js.effort.resize(0);
-
-		js.name[0] = m_topic_name;
-
-		const int32_t pos = m_device.get_entry(m_position_actual_field);
-		js.header.stamp = ros::Time::now();
-		js.position[0] = pos_to_rad(pos);
-
-		DEBUG_LOG("Sending JointState message");
-		DEBUG_DUMP(pos);
-		DEBUG_DUMP(js.position[0]);
-
-		m_publisher.publish(js);
-
-	} catch (const sdo_error& error) {
-		// TODO: only catch timeouts?
-		ERROR("Exception in JointStatePublisher::publish(): "<<error.what());
+		if (m_topic_name.empty())
+		{
+			uint8_t node_id = device.get_node_id();
+			m_topic_name = "device" + std::to_string(node_id) + "/get_joint_state";
+		}
 	}
 
-}
+	void JointStatePublisher::advertise()
+	{
 
-double JointStatePublisher::pos_to_rad(int32_t pos) const {
-	const double p = pos;
-	const double min = m_position_0_degree;
-	const double max = m_position_360_degree;
-	const double dist = max - min;
-	const double result = ((p-min)/dist)*2*pi();
-	return result;
-}
+		assert(!m_topic_name.empty());
+		DEBUG_LOG("Advertising " << m_topic_name);
+		ros::NodeHandle nh;
+		m_publisher = nh.advertise<sensor_msgs::JointState>(m_topic_name, queue_size);
+		m_initialized = true;
+	}
+
+	void JointStatePublisher::publish()
+	{
+
+		try
+		{
+
+			if (!m_initialized)
+			{
+				throw std::runtime_error("[JointStatePublisher] publish() called before advertise().");
+			}
+
+			sensor_msgs::JointState js;
+
+			// only position and velocity supported yet.
+
+			js.name.resize(1);
+			js.position.resize(1);
+			js.velocity.resize(1);
+			js.effort.resize(1);
+
+			const int32_t pos = m_device.get_entry(m_position_actual_field);
+			const int32_t vel = m_device.get_entry(m_velocity_actual_field);
+			const int32_t tor = m_device.get_entry(m_torque_actual_field);
+
+			js.name[0] = m_topic_name;
+
+			js.header.stamp = ros::Time::now();
+			js.position[0] = pos_to_rev(pos);
+			js.velocity[0] = vel_to_rev_p_s(vel);
+			js.effort[0] = tor_to_eff(tor);
+
+			DEBUG_LOG("Sending JointState message");
+			DEBUG_LOG("Position:");
+			DEBUG_DUMP(pos);
+			DEBUG_DUMP(js.position[0]);
+			DEBUG_LOG("Velocity:");
+			DEBUG_DUMP(vel);
+			DEBUG_DUMP(js.velocity[0]);
+			DEBUG_LOG("Effort:");
+			DEBUG_DUMP(tor);
+			DEBUG_DUMP(js.effort[0]);
+
+			m_publisher.publish(js);
+		}
+		catch (const sdo_error &error)
+		{
+			// TODO: only catch timeouts?
+			ERROR("Exception in JointStatePublisher::publish(): " << error.what());
+		}
+	}
+
+	double JointStatePublisher::pos_to_rev(int32_t pos) const
+	{
+		const double p = pos;
+		const double min = m_position_0_degree;
+		const double max = m_position_360_degree;
+		const double dist = max - min;
+		const double result = ((p - min) / dist);
+		return result;
+	}
+
+	double JointStatePublisher::vel_to_rev_p_s(int32_t vel) const
+	{
+		const double v = vel;
+		const double nom = m_velocity_nominator;
+		const double denom = m_velocity_denominator;
+		const double result = v * (nom / denom);
+		return result;
+	}
+
+	double JointStatePublisher::tor_to_eff(int32_t tor) const
+	{
+		return (double)((double)tor) / 1000.0;
+	}
 
 } // end namespace kaco


### PR DESCRIPTION
This PR allows users to use a position, velocity, or effort mode via ROS bridge with kacanopen.

The available modes are: `"profile_position_mode"`, `"profile_velocity_mode"`,  and `"effort_mode"`
Thus, instead of

```c++
device.set_entry("modes_of_operation", device.get_constant("profile_position_mode"));
```

you can also write

```c++
device.set_entry("modes_of_operation", device.get_constant("profile_velocity_mode"));
```

or 

```c++
device.set_entry("modes_of_operation", device.get_constant("torque_mode"));
```

While this PR does not include mode changes on-the-fly, users could write their ROS bridge to stop the motor and re-initialize it in a different mode.

If you have any more questions or need any help, feel free to contact me :)