### PR TITLE
Fix concurrent access to devices list

### DIFF
--- a/master/include/master.h
+++ b/master/include/master.h
@@ -101,12 +101,12 @@ namespace kaco {
 
 		std::vector<std::unique_ptr<Device>> m_devices;
 		std::bitset<265> m_device_alive;
+		mutable std::mutex m_devices_mutex;
 
 		NMT::DeviceAliveCallback m_device_alive_callback_functional;
 		bool m_running{false};
 
 		void device_alive_callback(const uint8_t node_id);
-
 	};
 
 } // end namespace kaco

--- a/master/src/master.cpp
+++ b/master/src/master.cpp
@@ -78,15 +78,18 @@ void Master::stop() {
 }
 
 size_t Master::num_devices() const {
+	std::lock_guard<std::mutex> scoped_lock(m_devices_mutex);
 	return m_devices.size();
 }
 
 Device& Master::get_device(size_t index) const {
+	std::lock_guard<std::mutex> scoped_lock(m_devices_mutex);
 	assert(m_devices.size()>index);
 	return *(m_devices.at(index).get());
 }
 
 void Master::device_alive_callback(const uint8_t node_id) {
+	std::lock_guard<std::mutex> scoped_lock(m_devices_mutex);
 	if (!m_device_alive.test(node_id)) {
 		m_device_alive.set(node_id);
 		m_devices.emplace_back(new Device(core, node_id));


### PR DESCRIPTION
Fix concurrent access to devices list.
Without this fix Kacanopen can say device is already know but get_device cannot find this device